### PR TITLE
Fix README sub tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pip install -r scripts/requirements.txt
 # rebuild catalogue & README counts (CI & pre‑commit do this automatically)
 python scripts/build_index.py
 ```
-Need a demo or enterprise implementation? Contact <a href="https://x.com/alexbilz">Alex Bilzerian</a></sub>
+<sub>Need a demo or enterprise implementation? Contact <a href="https://x.com/alexbilz">Alex Bilzerian</a></sub>
 
 ⸻
 


### PR DESCRIPTION
## Summary
- close dangling `</sub>` in README

No tests run because this is documentation only.

------
https://chatgpt.com/codex/tasks/task_e_6841c645522c83249ef8ee53501b6455