### PR TITLE
Add ruff and markdownlint pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - name: Build prompt index
-      run: |
-        python scripts/build_index.py
-        git diff --exit-code prompts/INDEX.md
-    - name: Test example (placeholder)
-      run: echo "Add your tests here"
+    - name: Install pre-commit
+      run: pip install pre-commit
+    - name: Run pre-commit checks
+      run: pre-commit run --all-files

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,14 @@
+default: true
+MD013: false
+MD033: false
+MD041: false
+MD024: false
+MD040: false
+MD010: false
+MD045: false
+MD022: false
+MD031: false
+MD004: false
+MD012: false
+MD032: false
+MD047: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,12 @@ repos:
         entry: python scripts/build_index.py
         language: system
         pass_filenames: false
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.12
+    hooks:
+    - id: ruff
+-   repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.45.0
+    hooks:
+    - id: markdownlint
+      args: ["-c", ".markdownlint.yaml"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,4 +164,4 @@ A: The GitHub Pages site auto-builds from `main` after `build_index.py` updates 
 
 ---
 
-**You are now ready. Build responsibly ✨**
+You are now ready. Build responsibly ✨

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -4,7 +4,9 @@ Builds prompts/INDEX.md with a table of all prompt files.
 Run from repo root:  python scripts/build_index.py
 """
 
-import pathlib, re, textwrap
+import pathlib
+import re
+import textwrap
 from urllib.parse import quote
 
 PROMPTS_DIR = pathlib.Path("prompts")

--- a/scripts/financial_metacognition/examples/test_financial_metacognition.py
+++ b/scripts/financial_metacognition/examples/test_financial_metacognition.py
@@ -55,7 +55,7 @@ def main():
             response = f.read()
         
         print(f"\n{'='*80}")
-        print(f"TESTING FINANCIAL METACOGNITION ANALYSIS WITH CONFIGURATION:")
+        print("TESTING FINANCIAL METACOGNITION ANALYSIS WITH CONFIGURATION:")
         print(f"Region: {args.region}")
         print(f"Sentiment Analysis: {'Enabled' if args.sentiment else 'Disabled'}")
         print(f"Expected Accounting Standard: {args.accounting_standard}")

--- a/scripts/financial_metacognition/financial_metacognition.py
+++ b/scripts/financial_metacognition/financial_metacognition.py
@@ -2,13 +2,11 @@
 """
 Financial metacognition analysis tool for evaluating AI interpretations of financial prompts.
 """
-import re
 import json
 import argparse
 import os
-from typing import List, Dict, Any, Optional, Tuple
+from typing import List, Dict, Any, Optional
 import datetime
-import sys
 import spacy
 from spacy.matcher import Matcher
 

--- a/scripts/prompt_analyzer.py
+++ b/scripts/prompt_analyzer.py
@@ -12,8 +12,7 @@ import argparse
 import json
 import statistics
 from collections import defaultdict, Counter
-from typing import Dict, List, Tuple, Any, Optional
-import math
+from typing import Dict, List, Tuple, Any
 import random
 
 # Check if nltk is available (for advanced text analysis)
@@ -278,9 +277,7 @@ class PromptAnalyzer:
             complexity_count += len(re.findall(indicator_pattern, content, re.IGNORECASE))
         
         # Calculate base score
-        content_length = len(content)
-        weight = min(1.0, 1000 / content_length) if content_length > 0 else 0.5
-        
+
         # More instructions are good, more complexity is bad
         base_score = 50 + (instruction_count * 5) - (complexity_count * 3)
         

--- a/scripts/prompt_evolution.py
+++ b/scripts/prompt_evolution.py
@@ -12,7 +12,7 @@ import argparse
 import json
 import random
 import time
-from typing import Dict, List, Tuple, Any, Optional, Callable
+from typing import Dict, List, Any
 import statistics
 from datetime import datetime
 
@@ -306,13 +306,13 @@ class PromptEvolution:
             )
         else:
             user_message += (
-                f"Create a comprehensive prompt that will guide an AI to accomplish this task "
-                f"effectively. Include:\n"
-                f"1. A clear title\n"
-                f"2. Configuration options (like 'be concise', 'step by step', etc.)\n"
-                f"3. Detailed instructions\n"
-                f"4. Example outputs in a code block\n"
-                f"5. Any other elements that will make the prompt more effective"
+                "Create a comprehensive prompt that will guide an AI to accomplish this task "
+                "effectively. Include:\n"
+                "1. A clear title\n"
+                "2. Configuration options (like 'be concise', 'step by step', etc.)\n"
+                "3. Detailed instructions\n"
+                "4. Example outputs in a code block\n"
+                "5. Any other elements that will make the prompt more effective"
             )
         
         # Simulate LLM response if not available

--- a/scripts/prompt_mixer.py
+++ b/scripts/prompt_mixer.py
@@ -11,7 +11,7 @@ import re
 import argparse
 import random
 import datetime
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, Optional
 
 
 class PromptElement:

--- a/scripts/token_counter.py
+++ b/scripts/token_counter.py
@@ -11,7 +11,7 @@ import re
 import argparse
 import sys
 import json
-from typing import Dict, List, Optional, Tuple
+from typing import Dict
 from collections import defaultdict
 
 # Check if tiktoken is available (for OpenAI models)

--- a/scripts/validate_prompts.py
+++ b/scripts/validate_prompts.py
@@ -10,7 +10,6 @@ import os
 import re
 import argparse
 import sys
-from typing import Dict, List, Set, Tuple
 
 
 class PromptValidator:
@@ -81,10 +80,10 @@ class PromptValidator:
                 
                 if not found_title:
                     if self.strict:
-                        file_issues.append(f"Missing title (should start with '# Title')")
+                        file_issues.append("Missing title (should start with '# Title')")
                         is_valid = False
                     else:
-                        file_warnings.append(f"Missing standard title format (should start with '# Title')")
+                        file_warnings.append("Missing standard title format (should start with '# Title')")
             
             # Check for some form of markdown code block, be more lenient
             code_block_found = False
@@ -121,10 +120,10 @@ class PromptValidator:
                 
                 if not found_indicator:
                     if self.strict:
-                        file_issues.append(f"Missing code block and no clear prompt indicators")
+                        file_issues.append("Missing code block and no clear prompt indicators")
                         is_valid = False
                     else:
-                        file_warnings.append(f"No clear code or instruction format detected")
+                        file_warnings.append("No clear code or instruction format detected")
             
             # Extract code block content for further analysis if we have triple backticks
             code_blocks = re.findall(r'```.*?\n(.*?)```', content, re.DOTALL)
@@ -174,7 +173,7 @@ class PromptValidator:
                         break
                 
                 if not found_instructions and self.strict:
-                    file_warnings.append(f"No clear instruction patterns detected")
+                    file_warnings.append("No clear instruction patterns detected")
                 
                 # Check for basic content length
                 if len(main_block.strip()) < 50:  # Very minimal length requirement


### PR DESCRIPTION
## Summary
- enable ruff and markdownlint in `.pre-commit-config.yaml`
- run `pre-commit run --all-files` in CI
- relax markdownlint rules
- fix ruff issues in scripts
- minor doc clean up in AGENTS

## Testing
- `pre-commit run --all-files`
- `python scripts/validate_prompts.py`
- `python scripts/build_index.py`


------
https://chatgpt.com/codex/tasks/task_e_6841c643a34c83248c6fd010d46c55f8