### PR TITLE
Fix failing linter warning

### DIFF
--- a/tests/test_token_counter.py
+++ b/tests/test_token_counter.py
@@ -1,4 +1,3 @@
-import pytest
 from scripts.token_counter import TokenCounter
 
 


### PR DESCRIPTION
## Summary
- remove unused pytest import in tests

## Testing
- `pytest -q`
- `ruff check tests`

------
https://chatgpt.com/codex/tasks/task_e_6841cdc0efc083248d026450f921523c