### PR TITLE
Remove extra blank line from token_counter test

### DIFF
--- a/tests/test_token_counter.py
+++ b/tests/test_token_counter.py
@@ -1,6 +1,5 @@
 from scripts.token_counter import TokenCounter
 
-
 def test_extract_content_strip_markdown():
     text = "# Title\nSome *bold* text\n- item"
     tc = TokenCounter(include_markdown=False)


### PR DESCRIPTION
## Summary
- tidy `tests/test_token_counter.py` to keep a single blank line after imports

## Testing
- `pre-commit run --files tests/test_token_counter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d538080c8324a90c2f9451e73abf