### PR TITLE
Add initial unit tests for prompt modules

### DIFF
--- a/tests/test_financial_metacognition.py
+++ b/tests/test_financial_metacognition.py
@@ -1,0 +1,16 @@
+import importlib
+import spacy
+
+
+def test_identify_financial_concepts(monkeypatch):
+    monkeypatch.setattr(spacy, "load", lambda name: spacy.blank("en"))
+    fm = importlib.import_module(
+        "scripts.financial_metacognition.financial_metacognition"
+    )
+    result = fm.identify_financial_concepts(
+        "Stocks rallied in the US market",
+        "The US stocks show growth",
+        region="US",
+    )
+    assert result["identified_concepts"]
+    assert result["concept_coverage"]["coverage_percentage"] >= 0

--- a/tests/test_prompt_analyzer.py
+++ b/tests/test_prompt_analyzer.py
@@ -1,0 +1,9 @@
+from scripts import prompt_analyzer
+
+
+def test_evaluate_improves_score(monkeypatch) -> None:
+    monkeypatch.setattr(prompt_analyzer, "NLTK_AVAILABLE", False)
+    analyzer = prompt_analyzer.PromptAnalyzer()
+    bad_prompt = "This is not clear."
+    good_prompt = "# Title\n\n```markdown\nreset\n```\nYour task is to be clear."
+    assert analyzer.evaluate(good_prompt) > analyzer.evaluate(bad_prompt)

--- a/tests/test_prompt_evolution.py
+++ b/tests/test_prompt_evolution.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from scripts.prompt_evolution import PromptEvolution
+
+
+def test_evolution_simulation(tmp_path: Path) -> None:
+    evo = PromptEvolution(
+        task_description="say hello",
+        output_dir=str(tmp_path),
+        population_size=2,
+        max_iterations=1,
+        verbose=False,
+        model="simulate",
+    )
+    results = evo.evolve()
+    assert results["best_prompt"]
+    # ensure output files were created
+    assert any(p.suffix == ".md" for p in tmp_path.iterdir())

--- a/tests/test_prompt_mixer.py
+++ b/tests/test_prompt_mixer.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from scripts.prompt_mixer import PromptMixer
+
+
+def create_prompt(path: Path, title: str, instruction: str) -> None:
+    content = f"# {title}\n\n```markdown\n`reset`\n`no quotes`\n\n{instruction}\n```\n"
+    path.write_text(content)
+
+
+def test_mixer_combines_sections(tmp_path: Path) -> None:
+    root = tmp_path / "prompts"
+    root.mkdir()
+    prompt_a = root / "a.md"
+    prompt_b = root / "b.md"
+
+    create_prompt(prompt_a, "Alpha", "You should respond briefly.")
+    create_prompt(prompt_b, "Beta", "Your task is to compute numbers.")
+
+    mixer = PromptMixer(root_dir=str(root), output_dir=str(tmp_path))
+    mixer.scan_prompts()
+
+    output = mixer.create_mixed_prompt(
+        title="Mixed", use_instructions_from="a.md", use_output_from="b.md"
+    )
+    assert output is not None
+    mixed_content = Path(output).read_text()
+    assert "You should respond briefly." in mixed_content
+    assert "b.md" in mixed_content


### PR DESCRIPTION
## Summary
- test prompt mixer output for combined instructions
- test analyzer scoring behavior sans NLTK
- test prompt evolution loop in simulation mode
- test financial metacognition concept detection with a lightweight spaCy model

## Testing
- `ruff check tests/test_prompt_mixer.py tests/test_prompt_analyzer.py tests/test_prompt_evolution.py tests/test_financial_metacognition.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e6f833e483249088d41ab0b55358