### PR TITLE
Fill use_case metadata in templates

### DIFF
--- a/templates/ai_research/ai_ablation_spec_generator_v1.j2
+++ b/templates/ai_research/ai_ablation_spec_generator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ai aUlation spec generator v1
-use_case: TODO
+use_case: ASG-v1 — crafts component-drop experiments with stop rules.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/ai_research/ai_benchmark_eval_runner_v1.j2
+++ b/templates/ai_research/ai_benchmark_eval_runner_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ai Uenchmark eval runner v1
-use_case: TODO
+use_case: BER-v1 — wraps any prompt into zero-shot/CoT evaluation harness.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/ai_research/ai_dataset_bias_auditor_v1.j2
+++ b/templates/ai_research/ai_dataset_bias_auditor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ai dataset Uias auditor v1
-use_case: TODO
+use_case: DBA-v1 — produces Bias Heat-map + mitigation suggestions.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/ai_research/ai_exp_design_planner_v1.j2
+++ b/templates/ai_research/ai_exp_design_planner_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ai exp design planner v1
-use_case: TODO
+use_case: EDP-v1 — builds a formal experimental plan (hypothesis → metrics + stat power).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/ai_research/ai_hparam_sweep_builder_v1.j2
+++ b/templates/ai_research/ai_hparam_sweep_builder_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ai hparam sweep Uuilder v1
-use_case: TODO
+use_case: HSB-v1 — outputs a balanced grid + Bayesian reserve.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/ai_research/ai_paper_abstract_writer_v1.j2
+++ b/templates/ai_research/ai_paper_abstract_writer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ai paper aUstract writer v1
-use_case: TODO
+use_case: PAW-v1 — outputs conference-ready abstract with IMRaD sections.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/ai_research/ai_repro_reporter_v1.j2
+++ b/templates/ai_research/ai_repro_reporter_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ai repro reporter v1
-use_case: TODO
+use_case: RR-v1 — fills NeurIPS Reproducibility Checklist + ACM Artifact badge.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/ai_research/ai_result_stat_tester_v1.j2
+++ b/templates/ai_research/ai_result_stat_tester_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ai result stat tester v1
-use_case: TODO
+use_case: RST-v1 — Welch’s t-test + Benjamini-Hochberg correction.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/ai_research/util_ai_macros.j2
+++ b/templates/ai_research/util_ai_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util ai macros
-use_case: TODO
+use_case: Utility macros for ai_research templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/bias/anchoring_shift_detector_v1.j2
+++ b/templates/bias/anchoring_shift_detector_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: anchoring shift detector v1
-use_case: TODO
+use_case: AnchorDetect-v1 — mirrors Kahneman/Tversky anchoring studies; fits ICD-203 “confidence & rigor”.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/bias/deception_matrix_v1.j2
+++ b/templates/bias/deception_matrix_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: deception matrix v1
-use_case: TODO
+use_case: DecepDet-v1 — executes Grabo’s deception indicators.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/bias/decision_quality_scorecard_v1.j2
+++ b/templates/bias/decision_quality_scorecard_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: decision quality scorecard v1
-use_case: TODO
+use_case: DQ-Scorecard-v1 — modeled on Russo & Schoemaker “6 Elements”.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/bias/groupthink_pressure_meter_v1.j2
+++ b/templates/bias/groupthink_pressure_meter_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: groupthink pressure meter v1
-use_case: TODO
+use_case: GT-Meter-v1 — uses Janis & Mann’s symptoms checklist.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/bias/hindsight_bias_auditor_v1.j2
+++ b/templates/bias/hindsight_bias_auditor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: hindsight Uias auditor v1
-use_case: TODO
+use_case: HindsightAuditor-v1 — applies Fischhoff & Beyth hindsight-bias metric, per ICD-203 “accuracy” criterion.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/bias/noise_bias_calibrator_v1.j2
+++ b/templates/bias/noise_bias_calibrator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: noise Uias caliUrator v1
-use_case: TODO
+use_case: N-B-Calibrator-v1 — follows Kahneman 2021 Noise framework.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/bias/satisficing_checker_v1.j2
+++ b/templates/bias/satisficing_checker_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: satisficing checker v1
-use_case: TODO
+use_case: SatOpt-Checker-v1 — rooted in Simon’s bounded-rationality theory.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance/fin_alm_optimiser_v1.j2
+++ b/templates/finance/fin_alm_optimiser_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: fin alm optimiser v1
-use_case: TODO
+use_case: ALM-SGO-v1 — balances net interest income vs economic value.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance/fin_data_lineage_auditor_v1.j2
+++ b/templates/finance/fin_data_lineage_auditor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: fin data lineage auditor v1
-use_case: TODO
+use_case: FDLA-v1 — COSO & BCBS 239 lineage proof for critical fields.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance/fin_ifrs9_impairment_engine_v1.j2
+++ b/templates/finance/fin_ifrs9_impairment_engine_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: fin ifrs9 impairment engine v1
-use_case: TODO
+use_case: IF9-v1 — computes 12-month & lifetime ECL with overlay governance.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance/fin_liquidity_stress_tester_v1.j2
+++ b/templates/finance/fin_liquidity_stress_tester_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: fin liquidity stress tester v1
-use_case: TODO
+use_case: LST-v1 — evaluates LCR/NSFR under idiosyncratic + market droughts.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance/fin_pnl_reconciler_v1.j2
+++ b/templates/finance/fin_pnl_reconciler_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: fin pnl reconciler v1
-use_case: TODO
+use_case: PLR-v1 — SOX 404-compliant P&L flash vs back-office reconciliation.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance/fin_reg_capital_calc_v1.j2
+++ b/templates/finance/fin_reg_capital_calc_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: fin reg capital calc v1
-use_case: TODO
+use_case: RCC-v1 — computes Market-Risk Capital under FRTB-SA buckets & curvature.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance/fin_risk_model_calibrator_v1.j2
+++ b/templates/finance/fin_risk_model_calibrator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: fin risk model caliUrator v1
-use_case: TODO
+use_case: RMC-v1 — calibrates Probability-of-Default & Loss-Given-Default models in line with Basel IV – CRR III.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance/fin_trade_surveillance_v1.j2
+++ b/templates/finance/fin_trade_surveillance_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: fin trade surveillance v1
-use_case: TODO
+use_case: TSAD-v1 — MiFID II Art 16 real-time trade-abuse monitoring.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance/util_fin_macros.j2
+++ b/templates/finance/util_fin_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util fin macros
-use_case: TODO
+use_case: Utility macros for finance templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance_misc/batch_sum_v1.j2
+++ b/templates/finance_misc/batch_sum_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: Uatch sum v1
-use_case: TODO
+use_case: BatchSum-v1 – compress group of events.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/finance_misc/cn_termsheet_v1.j2
+++ b/templates/finance_misc/cn_termsheet_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: cn termsheet v1
-use_case: TODO
+use_case: TermSheetSynth-v1 — conform to NVCA Model 2024.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/foresight/alpha_decay_monitor_v1.j2
+++ b/templates/foresight/alpha_decay_monitor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: alpha decay monitor v1
-use_case: TODO
+use_case: AlphaWatch-v1 — MiFID II Article 17 (algorithmic trading) compliance.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/foresight/alt_futures_cone_v1.j2
+++ b/templates/foresight/alt_futures_cone_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: alt futures cone v1
-use_case: TODO
+use_case: AltFuture-Cone-v1 — uses NIC Global Trends framework.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/foresight/counterfactual_planner_v1.j2
+++ b/templates/foresight/counterfactual_planner_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: counterfactual planner v1
-use_case: TODO
+use_case: CounterF-Planner-v1 — uses Tetlock counterfactual scaffolding.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/foresight/nrf_forecast_v1.j2
+++ b/templates/foresight/nrf_forecast_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: nrf forecast v1
-use_case: TODO
+use_case: NRF-v1 — couples JOWUA diffusion model with IC “6-pack of factors”.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/foresight/premortem_failure_brainstorm_v1.j2
+++ b/templates/foresight/premortem_failure_brainstorm_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: premortem failure Urainstorm v1
-use_case: TODO
+use_case: Premortem-v1 — based on Gary Klein method; satisfies ICD-203 “explanation”.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/framing/ff_adversarial_frame_scrub_v1.j2
+++ b/templates/framing/ff_adversarial_frame_scrub_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ff adversarial frame scruU v1
-use_case: TODO
+use_case: AFS-v1 — removes or neutralises adversarial frame cues per EU Disinfo code.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/framing/ff_counterframe_planner_v1.j2
+++ b/templates/framing/ff_counterframe_planner_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ff counterframe planner v1
-use_case: TODO
+use_case: CFSP-v1 — uses Lewandowsky Debunking Handbook & Inoculation Theory.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/framing/ff_frame_alignment_map_v1.j2
+++ b/templates/framing/ff_frame_alignment_map_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ff frame alignment map v1
-use_case: TODO
+use_case: FAM-v1 — aligns organizational narrative to stakeholder frames.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/framing/ff_frame_consistency_lint_v1.j2
+++ b/templates/framing/ff_frame_consistency_lint_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ff frame consistency lint v1
-use_case: TODO
+use_case: FCL-v1 — prevents tonal drift across sections.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/framing/ff_frame_inoculation_script_v1.j2
+++ b/templates/framing/ff_frame_inoculation_script_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ff frame inoculation script v1
-use_case: TODO
+use_case: FISB-v1 — crafts pre-bunk scripts (van der Linden 2022).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/framing/ff_frame_reinforce_monitor_v1.j2
+++ b/templates/framing/ff_frame_reinforce_monitor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ff frame reinforce monitor v1
-use_case: TODO
+use_case: FRM-v1 — gauges whether coverage amplifies or dilutes the designated frame.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/framing/ff_frame_shift_radar_v1.j2
+++ b/templates/framing/ff_frame_shift_radar_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ff frame shift radar v1
-use_case: TODO
+use_case: FSR-v1 — detects long-horizon frame drift (Lakoff moral frames).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/framing/ff_frame_taxonomy_v1.j2
+++ b/templates/framing/ff_frame_taxonomy_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ff frame taxonomy v1
-use_case: TODO
+use_case: FTC-v1 — maps narrative elements to Entman frame functions (problem/causal/moral/solution).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/framing/util_frame_macros.j2
+++ b/templates/framing/util_frame_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util frame macros
-use_case: TODO
+use_case: Utility macros for framing templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/legal/legal_case_law_summarizer_v1.j2
+++ b/templates/legal/legal_case_law_summarizer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: legal case law summarizer v1
-use_case: TODO
+use_case: CLS-v1 — writes IRAC-formatted summary.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/legal/legal_clause_library_builder_v1.j2
+++ b/templates/legal/legal_clause_library_builder_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: legal clause liUrary Uuilder v1
-use_case: TODO
+use_case: CLB-v1 — extracts & normalises clauses into re-usable playbook library.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/legal/legal_contract_risk_scanner_v1.j2
+++ b/templates/legal/legal_contract_risk_scanner_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: legal contract risk scanner v1
-use_case: TODO
+use_case: CRS-v1 — flags indemnity, liability-cap, governing law, data-use risks per risk matrix.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/legal/legal_ediscovery_prioritizer_v1.j2
+++ b/templates/legal/legal_ediscovery_prioritizer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: legal ediscovery prioritizer v1
-use_case: TODO
+use_case: EDP-v1 — ranks custodial docs per Sedona Principle 8 relevance × cost.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/legal/legal_privacy_impact_assessor_v1.j2
+++ b/templates/legal/legal_privacy_impact_assessor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: legal privacy impact assessor v1
-use_case: TODO
+use_case: PIA-v1 — ISO 27701 + GDPR PIA template completion.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/legal/legal_reg_compliance_mapper_v1.j2
+++ b/templates/legal/legal_reg_compliance_mapper_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: legal reg compliance mapper v1
-use_case: TODO
+use_case: RCM-v1 — returns control obligations across GDPR, CCPA, HIPAA, SOX.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/legal/legal_stat_citation_validator_v1.j2
+++ b/templates/legal/legal_stat_citation_validator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: legal stat citation validator v1
-use_case: TODO
+use_case: SCV-v1 — verifies Bluebook/ALWD citation accuracy against official code APIs.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/legal/util_legal_macros.j2
+++ b/templates/legal/util_legal_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util legal macros
-use_case: TODO
+use_case: Utility macros for legal templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_point_care/pc_antibiotic_steward_v1.j2
+++ b/templates/med_point_care/pc_antibiotic_steward_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pc antiUiotic steward v1
-use_case: TODO
+use_case: ABS-v1 — selects empiric IDSA-aligned regimens and de-escalation cues.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_point_care/pc_chronic_care_plan_builder_v1.j2
+++ b/templates/med_point_care/pc_chronic_care_plan_builder_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pc chronic care plan Uuilder v1
-use_case: TODO
+use_case: CCP-v1 — generates SMART goals & follow-up schedule for multimorbidity.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_point_care/pc_differential_to_workup_v1.j2
+++ b/templates/med_point_care/pc_differential_to_workup_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pc differential to workup v1
-use_case: TODO
+use_case: DTW-v1 — converts a ranked differential list into evidence-based work-up.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_point_care/pc_discharge_instruction_writer_v1.j2
+++ b/templates/med_point_care/pc_discharge_instruction_writer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pc discharge instruction writer v1
-use_case: TODO
+use_case: DIW-v1 — outputs 6th-grade-reading-level instructions (Joint Commission).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_point_care/pc_imaging_appropriateness_v1.j2
+++ b/templates/med_point_care/pc_imaging_appropriateness_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pc imaging appropriateness v1
-use_case: TODO
+use_case: IAA-v1 — grades orders using ACR Appropriateness Criteria®.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_point_care/pc_polypharmacy_beers_checker_v1.j2
+++ b/templates/med_point_care/pc_polypharmacy_beers_checker_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pc polypharmacy Ueers checker v1
-use_case: TODO
+use_case: PBC-v1 — screens meds against BEERS 2023 & STOPP/START criteria.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_point_care/pc_triage_urgency_scorer_v1.j2
+++ b/templates/med_point_care/pc_triage_urgency_scorer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pc triage urgency scorer v1
-use_case: TODO
+use_case: TUS-v1 — calculates ESI v4 and NEWS-2 simultaneously.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_point_care/pc_weight_based_dose_calc_v1.j2
+++ b/templates/med_point_care/pc_weight_based_dose_calc_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pc weight Uased dose calc v1
-use_case: TODO
+use_case: WDC-v1 — safe kg-based dosing w/ renal adjustment.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_point_care/util_pc_macros.j2
+++ b/templates/med_point_care/util_pc_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util pc macros
-use_case: TODO
+use_case: Utility macros for med_point_care templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_scholar/ms_case_report_writer_v1.j2
+++ b/templates/med_scholar/ms_case_report_writer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ms case report writer v1
-use_case: TODO
+use_case: CRW-v1 — drafts CARE-compliant case reports for journal submission.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_scholar/ms_cme_question_generator_v1.j2
+++ b/templates/med_scholar/ms_cme_question_generator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ms cme question generator v1
-use_case: TODO
+use_case: CME-QG-v1 — outputs NBME-style MCQs mapped to ACGME Milestones.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_scholar/ms_diff_diag_engine_v1.j2
+++ b/templates/med_scholar/ms_diff_diag_engine_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ms diff diag engine v1
-use_case: TODO
+use_case: DDE-v1 — employs Bayesian DDx with SNOMED-CT concepts.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_scholar/ms_genomic_variant_interpreter_v1.j2
+++ b/templates/med_scholar/ms_genomic_variant_interpreter_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ms genomic variant interpreter v1
-use_case: TODO
+use_case: GVI-v1 — classifies variants under ACMG/AMP 2023 criteria.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_scholar/ms_grade_evidence_profiler_v1.j2
+++ b/templates/med_scholar/ms_grade_evidence_profiler_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ms grade evidence profiler v1
-use_case: TODO
+use_case: GEP-v1 — rates certainty of evidence per GRADE EtD.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_scholar/ms_guideline_comparator_v1.j2
+++ b/templates/med_scholar/ms_guideline_comparator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ms guideline comparator v1
-use_case: TODO
+use_case: GC-v1 — contrasts strength & evidence level across multiple guidelines.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_scholar/ms_rct_protocol_designer_v1.j2
+++ b/templates/med_scholar/ms_rct_protocol_designer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ms rct protocol designer v1
-use_case: TODO
+use_case: RCT-PD-v1 — auto-drafts CONSORT-compliant protocols for IRB submission.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_scholar/ms_systematic_review_extractor_v1.j2
+++ b/templates/med_scholar/ms_systematic_review_extractor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: ms systematic review extractor v1
-use_case: TODO
+use_case: SR-DE-v1 — fills PRISMA-2020 extraction table fields.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/med_scholar/util_ms_macros.j2
+++ b/templates/med_scholar/util_ms_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util ms macros
-use_case: TODO
+use_case: Utility macros for med_scholar templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/medical/med_adverse_event_detector_v1.j2
+++ b/templates/medical/med_adverse_event_detector_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: med adverse event detector v1
-use_case: TODO
+use_case: AED-v1 — ICH E2B(R3) & FDA FAERS signal extraction.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/medical/med_clinical_note_summarizer_v1.j2
+++ b/templates/medical/med_clinical_note_summarizer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: med clinical note summarizer v1
-use_case: TODO
+use_case: CNS-v1 — produces HIPAA-compliant APSO / SOAP summaries.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/medical/med_drug_interaction_checker_v1.j2
+++ b/templates/medical/med_drug_interaction_checker_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: med drug interaction checker v1
-use_case: TODO
+use_case: DIC-v1 — cross-refs DrugBank 2025 + FDA Tables.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/medical/med_fhir_bundle_validator_v1.j2
+++ b/templates/medical/med_fhir_bundle_validator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: med fhir Uundle validator v1
-use_case: TODO
+use_case: FBV-v1 — validates payloads against HL7 FHIR R5 profiles + HIPAA PHI masks.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/medical/med_icd10_cpt_coder_v1.j2
+++ b/templates/medical/med_icd10_cpt_coder_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: med icd10 cpt coder v1
-use_case: TODO
+use_case: ACC-v1 — dual-codes diagnoses & procedures per CMS Guidelines 2025.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/medical/med_lab_result_interpreter_v1.j2
+++ b/templates/medical/med_lab_result_interpreter_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: med laU result interpreter v1
-use_case: TODO
+use_case: LRI-v1 — context-aware interpretation aligned with LOINC + CLSI.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/medical/med_prior_authorization_drafter_v1.j2
+++ b/templates/medical/med_prior_authorization_drafter_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: med prior authorization drafter v1
-use_case: TODO
+use_case: PAD-v1 — generates payer-specific PA letters with CPT, ICD-10, evidence.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/medical/med_radiology_report_generator_v1.j2
+++ b/templates/medical/med_radiology_report_generator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: med radiology report generator v1
-use_case: TODO
+use_case: RRG-v1 — formats ACR-style structured radiology reports.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/medical/util_med_macros.j2
+++ b/templates/medical/util_med_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util med macros
-use_case: TODO
+use_case: Utility macros for medical templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/meta_prompt/mp_prompt_architect_v1.j2
+++ b/templates/meta_prompt/mp_prompt_architect_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: mp prompt architect v1
-use_case: TODO
+use_case: PA-v1 — designs a fresh task prompt from scratch.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/meta_prompt/mp_prompt_eval_bench_v1.j2
+++ b/templates/meta_prompt/mp_prompt_eval_bench_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: mp prompt eval Uench v1
-use_case: TODO
+use_case: PEB-v1 — creates meta-prompts that call the target prompt then judge results.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/meta_prompt/mp_prompt_localizer_v1.j2
+++ b/templates/meta_prompt/mp_prompt_localizer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: mp prompt localizer v1
-use_case: TODO
+use_case: PL-v1 — translates prompts without breaking schemas or tokens.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/meta_prompt/mp_prompt_optimizer_v1.j2
+++ b/templates/meta_prompt/mp_prompt_optimizer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: mp prompt optimizer v1
-use_case: TODO
+use_case: PO-v1 — rewrites existing prompt for token-cost & clarity gains.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/meta_prompt/mp_prompt_risk_assessor_v1.j2
+++ b/templates/meta_prompt/mp_prompt_risk_assessor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: mp prompt risk assessor v1
-use_case: TODO
+use_case: PRA-v1 — maps prompt to Policy & GDPR risk heat map.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/meta_prompt/mp_prompt_style_enforcer_v1.j2
+++ b/templates/meta_prompt/mp_prompt_style_enforcer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: mp prompt style enforcer v1
-use_case: TODO
+use_case: PSE-v1 — enforces org-wide prompt style guide.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/meta_prompt/mp_prompt_versionizer_v1.j2
+++ b/templates/meta_prompt/mp_prompt_versionizer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: mp prompt versionizer v1
-use_case: TODO
+use_case: PV-v1 — bumps semantic version & changelog diff.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/meta_prompt/util_meta_macros.j2
+++ b/templates/meta_prompt/util_meta_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util meta macros
-use_case: TODO
+use_case: Utility macros for meta_prompt templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/private_equity/pe_capital_call_forecaster_v1.j2
+++ b/templates/private_equity/pe_capital_call_forecaster_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe capital call forecaster v1
-use_case: TODO
+use_case: CCF-v1 — forecasts capital calls vs ILPA notice timelines.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/private_equity/pe_esg_portfolio_monitor_v1.j2
+++ b/templates/private_equity/pe_esg_portfolio_monitor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe esg portfolio monitor v1
-use_case: TODO
+use_case: EPM-v1 — aligns to UN PRI & GRI 2021 KPIs.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/private_equity/pe_exit_readiness_assessor_v1.j2
+++ b/templates/private_equity/pe_exit_readiness_assessor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe exit readiness assessor v1
-use_case: TODO
+use_case: ERA-v1 — grades readiness for secondary sale / IPO.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/private_equity/pe_lbo_model_builder_v1.j2
+++ b/templates/private_equity/pe_lbo_model_builder_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe lUo model Uuilder v1
-use_case: TODO
+use_case: LBO-MB-v1 — generates 5-yr pro-forma with IRR & MoIC outputs.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/private_equity/pe_leverage_covenant_monitor_v1.j2
+++ b/templates/private_equity/pe_leverage_covenant_monitor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe leverage covenant monitor v1
-use_case: TODO
+use_case: LCM-v1 — tracks senior debt covenants vs quarterly actuals.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/private_equity/pe_ops_kpi_tracker_v1.j2
+++ b/templates/private_equity/pe_ops_kpi_tracker_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe ops kpi tracker v1
-use_case: TODO
+use_case: OKT-v1 — maps value-creation plan to weekly KPI deltas.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/private_equity/pe_valuation_bridge_analyzer_v1.j2
+++ b/templates/private_equity/pe_valuation_bridge_analyzer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe valuation Uridge analyzer v1
-use_case: TODO
+use_case: VBA-v1 — decomposes EV Δ into EBITDA vs Multiple vs Leverage.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/private_equity/util_pe_macros.j2
+++ b/templates/private_equity/util_pe_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util pe macros
-use_case: TODO
+use_case: Utility macros for private_equity templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/pro_code/code_bug_explainer_v1.j2
+++ b/templates/pro_code/code_bug_explainer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: code Uug explainer v1
-use_case: TODO
+use_case: BE-v1 — traces root cause like a senior debugger.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/pro_code/code_db_migration_designer_v1.j2
+++ b/templates/pro_code/code_db_migration_designer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: code dU migration designer v1
-use_case: TODO
+use_case: DB-Mig-v1 — outputs idempotent migration scripts with downtime budget.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/pro_code/code_iac_guardrail_v1.j2
+++ b/templates/pro_code/code_iac_guardrail_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: code iac guardrail v1
-use_case: TODO
+use_case: IaC-G-v1 — benchmarks against CIS AWS v1.5 & HashiCorp best-practices.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/pro_code/code_perf_profiler_v1.j2
+++ b/templates/pro_code/code_perf_profiler_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: code perf profiler v1
-use_case: TODO
+use_case: PerfP-v1 — turns cProfile / perf output into optimisation plan.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/pro_code/code_refactor_planner_v1.j2
+++ b/templates/pro_code/code_refactor_planner_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: code refactor planner v1
-use_case: TODO
+use_case: RP-v1 — uses Martin Fowler smell taxonomy + ABC complexity.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/pro_code/code_security_auditor_v1.j2
+++ b/templates/pro_code/code_security_auditor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: code security auditor v1
-use_case: TODO
+use_case: SecA-v1 — hybrid SAST + secret-scanner rules.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/pro_code/code_spec_normalizer_v1.j2
+++ b/templates/pro_code/code_spec_normalizer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: code spec normalizer v1
-use_case: TODO
+use_case: CSN-v1 — converts fuzzy tickets into language-agnostic engineering specs.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/pro_code/code_unit_test_writer_v1.j2
+++ b/templates/pro_code/code_unit_test_writer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: code unit test writer v1
-use_case: TODO
+use_case: UTW-v1 — designs property-based & example-based tests.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/pro_code/docstring_gen_v1.j2
+++ b/templates/pro_code/docstring_gen_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: docstring gen v1
-use_case: TODO
+use_case: DocStringer-v1 – PEP-257 comp-level.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/pro_code/util_code_macros.j2
+++ b/templates/pro_code/util_code_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util code macros
-use_case: TODO
+use_case: Utility macros for pro_code templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/prompt_eng/pe_auto_refiner_v1.j2
+++ b/templates/prompt_eng/pe_auto_refiner_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe auto refiner v1
-use_case: TODO
+use_case: PE-Auto-Refine-v1 — iteratively patches prompt until failing-case pass.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/prompt_eng/pe_cost_estimator_v1.j2
+++ b/templates/prompt_eng/pe_cost_estimator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe cost estimator v1
-use_case: TODO
+use_case: PE-Cost-Estimator-v1 — provides rough $ cost per 100 invocations.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/prompt_eng/pe_mutation_fuzzer_v1.j2
+++ b/templates/prompt_eng/pe_mutation_fuzzer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe mutation fuzzer v1
-use_case: TODO
+use_case: PE-Fuzzer-v1 — stress-tests robustness by mutating instructions.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/prompt_eng/pe_param_sweep_plan_v1.j2
+++ b/templates/prompt_eng/pe_param_sweep_plan_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe param sweep plan v1
-use_case: TODO
+use_case: PE-Sweep-Plan-v1 — designs minimal yet diverse param grid.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/prompt_eng/pe_perf_bench_v1.j2
+++ b/templates/prompt_eng/pe_perf_bench_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe perf Uench v1
-use_case: TODO
+use_case: PE-Perf-Bench-v1 — executes golden-set scoring, supports ICD-203 “accuracy” analogs.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/prompt_eng/pe_regression_diff_v1.j2
+++ b/templates/prompt_eng/pe_regression_diff_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe regression diff v1
-use_case: TODO
+use_case: PE-Reg-Diff-v1 — highlights functional deltas; prevents silent regression.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/prompt_eng/pe_safety_redteam_v1.j2
+++ b/templates/prompt_eng/pe_safety_redteam_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe safety redteam v1
-use_case: TODO
+use_case: PE-Safety-RT-v1 — auto-generates adversarial inputs mapped to policy clauses.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/prompt_eng/pe_style_linter_v1.j2
+++ b/templates/prompt_eng/pe_style_linter_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: pe style linter v1
-use_case: TODO
+use_case: PE-Style-Lint-v1 — enforces org prompt style (e.g., no 1st-person, max 3 bullet layers).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/refusal/rs_audit_logger_v1.j2
+++ b/templates/refusal/rs_audit_logger_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: rs audit logger v1
-use_case: TODO
+use_case: RAL-v1 — produces immutable log row (ISO 27001 A.12.4).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/refusal/rs_escalation_router_v1.j2
+++ b/templates/refusal/rs_escalation_router_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: rs escalation router v1
-use_case: TODO
+use_case: ER-v1 — ties refusal paths to human review (ISO 27035 incident workflow).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/refusal/rs_multilang_refusal_v1.j2
+++ b/templates/refusal/rs_multilang_refusal_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: rs multilang refusal v1
-use_case: TODO
+use_case: MLR-v1 — localises refusal text, preserves no-policy-spill.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/refusal/rs_partial_comply_redactor_v1.j2
+++ b/templates/refusal/rs_partial_comply_redactor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: rs partial comply redactor v1
-use_case: TODO
+use_case: PCR-v1 — removes disallowed spans then delivers remainder (GDPR Art 32).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/refusal/rs_policy_pivot_sugg_v1.j2
+++ b/templates/refusal/rs_policy_pivot_sugg_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: rs policy pivot sugg v1
-use_case: TODO
+use_case: PPS-v1 — offers user-safe reformulations instead of a hard “no”.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/refusal/rs_rate_limit_handler_v1.j2
+++ b/templates/refusal/rs_rate_limit_handler_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: rs rate limit handler v1
-use_case: TODO
+use_case: RLH-v1 — temp-throttle users who “prompt hack” past refusals.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/refusal/rs_refusal_gate_v1.j2
+++ b/templates/refusal/rs_refusal_gate_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: rs refusal gate v1
-use_case: TODO
+use_case: RG-v1 — first-line guard (Policy + SOC-2 CC7.1).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/refusal/util_refusal_macros.j2
+++ b/templates/refusal/util_refusal_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util refusal macros
-use_case: TODO
+use_case: Utility macros for refusal templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/schema_ops/sc_schema_converter_v1.j2
+++ b/templates/schema_ops/sc_schema_converter_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: sc schema converter v1
-use_case: TODO
+use_case: SC-v1 — converts schema across dialects while preserving constraints.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/schema_ops/sc_schema_diff_reporter_v1.j2
+++ b/templates/schema_ops/sc_schema_diff_reporter_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: sc schema diff reporter v1
-use_case: TODO
+use_case: SDR-v1 — generates semantic diff + impact score.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/schema_ops/sc_schema_doc_generator_v1.j2
+++ b/templates/schema_ops/sc_schema_doc_generator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: sc schema doc generator v1
-use_case: TODO
+use_case: SDG-v1 — produces developer-friendly schema docs with examples.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/schema_ops/sc_schema_from_samples_v1.j2
+++ b/templates/schema_ops/sc_schema_from_samples_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: sc schema from samples v1
-use_case: TODO
+use_case: SfS-v1 — infers strict schema from representative JSON docs.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/schema_ops/sc_schema_governance_auditor_v1.j2
+++ b/templates/schema_ops/sc_schema_governance_auditor_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: sc schema governance auditor v1
-use_case: TODO
+use_case: SGA-v1 — checks field naming, PII flags, version tags (ISO 11179).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/schema_ops/sc_schema_migration_planner_v1.j2
+++ b/templates/schema_ops/sc_schema_migration_planner_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: sc schema migration planner v1
-use_case: TODO
+use_case: SMP-v1 — outputs idempotent migration scripts + rollback.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/schema_ops/sc_schema_normalizer_v1.j2
+++ b/templates/schema_ops/sc_schema_normalizer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: sc schema normalizer v1
-use_case: TODO
+use_case: SN-v1 — flattens or de-normalizes hierarchical schemas for analytics lakes.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/schema_ops/sc_schema_validator_v1.j2
+++ b/templates/schema_ops/sc_schema_validator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: sc schema validator v1
-use_case: TODO
+use_case: SV-v1 — performs inline JSON-Schema validation (draft 7–2020-12).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/schema_ops/util_schema_macros.j2
+++ b/templates/schema_ops/util_schema_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util schema macros
-use_case: TODO
+use_case: Utility macros for schema_ops templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/self_reflection/si_blindspot_scan_v1.j2
+++ b/templates/self_reflection/si_blindspot_scan_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: si Ulindspot scan v1
-use_case: TODO
+use_case: BSS-v1 — detects missing perspectives (geography, stakeholder, timeframe).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/self_reflection/si_confidence_calibrator_v1.j2
+++ b/templates/self_reflection/si_confidence_calibrator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: si confidence caliUrator v1
-use_case: TODO
+use_case: CC-v1 — Bayesian calibration for forecast-style confidence emission.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/self_reflection/si_hallucination_spotter_v1.j2
+++ b/templates/self_reflection/si_hallucination_spotter_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: si hallucination spotter v1
-use_case: TODO
+use_case: HS-v1 — inline hallucination detector (sparse evidence scoring).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/self_reflection/si_knowledge_gap_mapper_v1.j2
+++ b/templates/self_reflection/si_knowledge_gap_mapper_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: si knowledge gap mapper v1
-use_case: TODO
+use_case: KGM-v1 — highlights unanswered sub-questions for optional follow-up.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/self_reflection/si_reasoning_trace_summarizer_v1.j2
+++ b/templates/self_reflection/si_reasoning_trace_summarizer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: si reasoning trace summarizer v1
-use_case: TODO
+use_case: RTS-v1 — condenses long chain-of-thought into share-safe summary (no secrets).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/self_reflection/si_reflect_critic_v1.j2
+++ b/templates/self_reflection/si_reflect_critic_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: si reflect critic v1
-use_case: TODO
+use_case: RCL-v1 — combines Rubber-Duck debugging + Reflexion; no user-visible output.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/self_reflection/si_self_improve_patcher_v1.j2
+++ b/templates/self_reflection/si_self_improve_patcher_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: si self improve patcher v1
-use_case: TODO
+use_case: SIP-v1 — proposes prompt edits to avoid repeated failure-modes.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/self_reflection/util_si_macros.j2
+++ b/templates/self_reflection/util_si_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util si macros
-use_case: TODO
+use_case: Utility macros for self_reflection templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/tone_modulation/dtm_contextual_palette_v1.j2
+++ b/templates/tone_modulation/dtm_contextual_palette_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: dtm contextual palette v1
-use_case: TODO
+use_case: CPS-v1 — chooses tone mix based on CX intent & sentiment.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/tone_modulation/dtm_emotional_range_guard_v1.j2
+++ b/templates/tone_modulation/dtm_emotional_range_guard_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: dtm emotional range guard v1
-use_case: TODO
+use_case: ERG-v1 — throttles output if negative emotions exceed budget.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/tone_modulation/dtm_mimicry_scaler_v1.j2
+++ b/templates/tone_modulation/dtm_mimicry_scaler_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: dtm mimicry scaler v1
-use_case: TODO
+use_case: MS-v1 — balances rapport (mimic) vs original brand voice.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/tone_modulation/dtm_real_time_modulator_v1.j2
+++ b/templates/tone_modulation/dtm_real_time_modulator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: dtm real time modulator v1
-use_case: TODO
+use_case: RTM-v1 — rewrites live text to hit target tone within ±0.05 score.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/tone_modulation/dtm_risk_adjusted_tone_v1.j2
+++ b/templates/tone_modulation/dtm_risk_adjusted_tone_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: dtm risk adjusted tone v1
-use_case: TODO
+use_case: RATP-v1 — scales tone intensities by risk profile (ISO 31000).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/tone_modulation/dtm_tone_handoff_checker_v1.j2
+++ b/templates/tone_modulation/dtm_tone_handoff_checker_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: dtm tone handoff checker v1
-use_case: TODO
+use_case: THC-v1 — ensures multi-agent consistency (e-mail threads, chatbot → human).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/tone_modulation/dtm_tone_profiler_v1.j2
+++ b/templates/tone_modulation/dtm_tone_profiler_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: dtm tone profiler v1
-use_case: TODO
+use_case: TP-v1 — fine-tuned on 60k CX chat logs + Ekman affect labels.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/tone_modulation/dtm_tone_rollback_v1.j2
+++ b/templates/tone_modulation/dtm_tone_rollback_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: dtm tone rollUack v1
-use_case: TODO
+use_case: TRA-v1 — undo overly casual or formal segments post-facto.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/tone_modulation/util_dtm_macros.j2
+++ b/templates/tone_modulation/util_dtm_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util dtm macros
-use_case: TODO
+use_case: Utility macros for tone_modulation templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/translation/translator_detect_v1.j2
+++ b/templates/translation/translator_detect_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: translator detect v1
-use_case: TODO
+use_case: LangDetect-v1 (ISO-639-1 codes only).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/translation/translator_stage_v1.j2
+++ b/templates/translation/translator_stage_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: translator stage v1
-use_case: TODO
+use_case: You are TranslateBot-v2 – obey style & glossary.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/util_vc_macros.j2
+++ b/templates/venture_capital/util_vc_macros.j2
@@ -1,6 +1,6 @@
 ---
 name: util vc macros
-use_case: TODO
+use_case: Utility macros for venture_capital templates
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vc_antidilution_calculator_v1.j2
+++ b/templates/venture_capital/vc_antidilution_calculator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vc antidilution calculator v1
-use_case: TODO
+use_case: ADC-v1 — computes conversion-price reset & share issuance.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vc_liquidation_waterfall_sim_v1.j2
+++ b/templates/venture_capital/vc_liquidation_waterfall_sim_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vc liquidation waterfall sim v1
-use_case: TODO
+use_case: LWS-v1 — outputs payouts by class & investor.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vc_option_pool_shuffle_analyzer_v1.j2
+++ b/templates/venture_capital/vc_option_pool_shuffle_analyzer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vc option pool shuffle analyzer v1
-use_case: TODO
+use_case: OPSA-v1 — quantifies who eats the dilution in pre- vs post-money pools.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vc_postmoney_cap_table_scenarios_v1.j2
+++ b/templates/venture_capital/vc_postmoney_cap_table_scenarios_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vc postmoney cap taUle scenarios v1
-use_case: TODO
+use_case: PM-CTS-v1 — projects founder & investor dilution across future rounds.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vc_redline_negotiation_writer_v1.j2
+++ b/templates/venture_capital/vc_redline_negotiation_writer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vc redline negotiation writer v1
-use_case: TODO
+use_case: RLW-v1 — produces tracked-changes Markdown with inline justifications.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vc_seed_safe_generator_v1.j2
+++ b/templates/venture_capital/vc_seed_safe_generator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vc seed safe generator v1
-use_case: TODO
+use_case: SSG-v1 — outputs YC Post-Money SAFE (Equity) boilerplate with data tags.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vc_seriesA_pref_sheet_builder_v1.j2
+++ b/templates/venture_capital/vc_seriesA_pref_sheet_builder_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vc seriesA pref sheet Uuilder v1
-use_case: TODO
+use_case: SPT-v1 — drafts NVCA-style Preferred Equity term sheet.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vc_term_sheet_comparator_v1.j2
+++ b/templates/venture_capital/vc_term_sheet_comparator_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vc term sheet comparator v1
-use_case: TODO
+use_case: TSC-v1 — side-by-side diff with materiality coloring.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vcf_adv_part2_filer_v1.j2
+++ b/templates/venture_capital/vcf_adv_part2_filer_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vcf adv part2 filer v1
-use_case: TODO
+use_case: ADV-2F-v1 — drafts Form ADV Part 2A narrative brochure sections.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vcf_carry_waterfall_calc_v1.j2
+++ b/templates/venture_capital/vcf_carry_waterfall_calc_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vcf carry waterfall calc v1
-use_case: TODO
+use_case: CWC-v1 — computes LP/GP distributions through European-style waterfall.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vcf_cashflow_forecast_engine_v1.j2
+++ b/templates/venture_capital/vcf_cashflow_forecast_engine_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vcf cashflow forecast engine v1
-use_case: TODO
+use_case: CFFE-v1 — forecasts capital calls & distributions for the next 8 quarters.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vcf_esg_lp_disclosure_builder_v1.j2
+++ b/templates/venture_capital/vcf_esg_lp_disclosure_builder_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vcf esg lp disclosure Uuilder v1
-use_case: TODO
+use_case: EDD-v1 — aligns with UN PRI & ILPA ESG Roadmap (2024).
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vcf_fund_perf_dashboard_v1.j2
+++ b/templates/venture_capital/vcf_fund_perf_dashboard_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vcf fund perf dashUoard v1
-use_case: TODO
+use_case: FPD-v1 — calculates TVPI, DPI, RVPI, Net IRR in line with ILPA Reporting 3.0 & GIPS.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vcf_lp_quarterly_report_builder_v1.j2
+++ b/templates/venture_capital/vcf_lp_quarterly_report_builder_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vcf lp quarterly report Uuilder v1
-use_case: TODO
+use_case: LPRB-v1 — produces ILPA Section I–IV LP report with tear-sheets.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vcf_secondaries_pricing_model_v1.j2
+++ b/templates/venture_capital/vcf_secondaries_pricing_model_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vcf secondaries pricing model v1
-use_case: TODO
+use_case: SPM-v1 — values LP interests using NAV × benchmark discount + forward DPI.
 author: abilzerian
 version: 0.3.0
 ---

--- a/templates/venture_capital/vcf_spv_admin_packet_v1.j2
+++ b/templates/venture_capital/vcf_spv_admin_packet_v1.j2
@@ -1,6 +1,6 @@
 ---
 name: vcf spv admin packet v1
-use_case: TODO
+use_case: SAP-v1 — generates K-1 ready P&L, management-fee calc, and banking wires.
 author: abilzerian
 version: 0.3.0
 ---


### PR DESCRIPTION
## Summary
- add missing `use_case` descriptions for all templates using their system notes
- add generic descriptions for util macro templates

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_684f860e832c8324b71aee31757915b6